### PR TITLE
Fix command formatting for commands with long names

### DIFF
--- a/lib/commander/help_formatters/terminal/help.erb
+++ b/lib/commander/help_formatters/terminal/help.erb
@@ -1,3 +1,5 @@
+<% max_command_length = @commands.keys.max_by(&:size).size %>
+<% max_aliases_length = @aliases.keys.max_by(&:size).size %>
   <%= $terminal.color "NAME", :bold %>:
 
     <%= program :name %>
@@ -9,13 +11,13 @@
   <%= $terminal.color "COMMANDS", :bold %>:
 <% for name, command in @commands.sort -%>
 	<% unless alias? name %>
-    <%= "%-20s %s" % [command.name, command.summary || command.description] -%>
+    <%= "%-#{max_command_length}s %s" % [command.name, command.summary || command.description] -%>
 	<% end -%>
 <% end %>
 <% unless @aliases.empty? %>
   <%= $terminal.color "ALIASES", :bold %>:
   <% for alias_name, args in @aliases.sort %>
-    <%= "%-20s %s %s" % [alias_name, command(alias_name).name, args.join(' ')] -%>
+    <%= "%-#{max_aliases_length}s %s %s" % [alias_name, command(alias_name).name, args.join(' ')] -%>
   <% end %>
 <% end %>
 <% unless @options.empty? -%>

--- a/lib/commander/help_formatters/terminal_compact/help.erb
+++ b/lib/commander/help_formatters/terminal_compact/help.erb
@@ -1,3 +1,5 @@
+<% max_command_length = @commands.keys.max_by(&:size).size %>
+<% max_aliases_length = @aliases.keys.max_by(&:size).size %>
   <%= program :name %>
 
   <%= program :description %>
@@ -5,13 +7,13 @@
   Commands:
 <% for name, command in @commands.sort -%>
 <% unless alias? name -%>
-    <%= "%-20s %s" % [command.name, command.summary || command.description] %>
+    <%= "%-#{max_command_length}s %s" % [command.name, command.summary || command.description] %>
 <% end -%>
 <% end -%>
 <% unless @aliases.empty? %>
   Aliases:
 <% for alias_name, args in @aliases.sort -%>
-    <%= "%-20s %s %s" % [alias_name, command(alias_name).name, args.join(' ')] %>
+    <%= "%-#{max_aliases_length}s %s %s" % [alias_name, command(alias_name).name, args.join(' ')] %>
 <% end -%>
 <% end %>
 <% unless @options.empty? -%>


### PR DESCRIPTION
By using the longest command and alias names to determine how much to
"indent" the descriptions.

Re-opened from https://github.com/tj/commander/issues/98