### PR TITLE
Fix negative Highline wrap

### DIFF
--- a/lib/commander/import.rb
+++ b/lib/commander/import.rb
@@ -1,8 +1,5 @@
 require 'commander'
 
-include Commander::UI
-include Commander::UI::AskForClass
-include Commander::Delegates
+include Commander::Methods
 
-$terminal.wrap_at = HighLine::SystemExtensions.terminal_size.first - 5 rescue 80 if $stdin.tty?
 at_exit { run! }

--- a/lib/commander/methods.rb
+++ b/lib/commander/methods.rb
@@ -4,11 +4,8 @@ module Commander
     include Commander::UI::AskForClass
     include Commander::Delegates
 
-    if $stdin.tty?
-      screen_width = HighLine::SystemExtensions.terminal_size.first rescue 80
-      if screen_width >= 5
-        $terminal.wrap_at = screen_width - 5
-      end
+    if $stdin.tty? && (cols = $terminal.output_cols) >= 5
+      $terminal.wrap_at = cols - 5
     end
   end
 end

--- a/lib/commander/methods.rb
+++ b/lib/commander/methods.rb
@@ -4,6 +4,11 @@ module Commander
     include Commander::UI::AskForClass
     include Commander::Delegates
 
-    $terminal.wrap_at = HighLine::SystemExtensions.terminal_size.first - 5 rescue 80 if $stdin.tty?
+    if $stdin.tty?
+      screen_width = HighLine::SystemExtensions.terminal_size.first rescue 80
+      if screen_width >= 5
+        $terminal.wrap_at = screen_width - 5
+      end
+    end
   end
 end

--- a/lib/commander/methods.rb
+++ b/lib/commander/methods.rb
@@ -4,7 +4,7 @@ module Commander
     include Commander::UI::AskForClass
     include Commander::Delegates
 
-    if $stdin.tty? && (cols = $terminal.output_cols) >= 5
+    if $stdin.tty? && (cols = $terminal.output_cols) >= 40
       $terminal.wrap_at = cols - 5
     end
   end


### PR DESCRIPTION
If a terminal reports it's screen width as < 5, wrap_at could become negative causing Highline to enter an infinite loop whilst wrapping.

This makes sure we don't set negative wrap_at values by ensuring the terminal screen width at least 5.

It also cleans up the duplicated code.