### PR TITLE
Multiline option descriptions

### DIFF
--- a/lib/commander/help_formatters/terminal/command_help.erb
+++ b/lib/commander/help_formatters/terminal/command_help.erb
@@ -29,7 +29,7 @@
 	<% for option in @options -%>
 
     <%= option[:switches].join ', ' %> 
-        <%= option[:description] %>
+        <%= Commander::HelpFormatter.indent 8, option[:description] %>
 	<% end -%>
 <% end -%>
 


### PR DESCRIPTION
9ea5c0f added indentation of program and command descriptions. However, I've found myself also sometimes wanting multiline option descriptions, like the `-u` option from `git-commit` have (shown below). This patch adds identing of option descriptions.

```
       -u[<mode>], --untracked-files[=<mode>]
           Show untracked files.

           The mode parameter is optional (defaults to all), and is used to specify the handling of untracked files; when -u is not used, the default is normal, i.e. show untracked files and directories.

           The possible options are:

           ·   no - Show no untracked files

           ·   normal - Shows untracked files and directories

           ·   all - Also shows individual files in untracked directories.

               The default can be changed using the status.showUntrackedFiles configuration variable documented in git-config(1).
```