### PR TITLE
Fix deprecation warning on ruby 2.3.0

### DIFF
--- a/lib/commander/user_interaction.rb
+++ b/lib/commander/user_interaction.rb
@@ -329,9 +329,8 @@ module Commander
         [Float, Integer, String, Symbol, Regexp, Array, File, Pathname] +
         # All Classes that respond to #parse
         Object.constants.map do |const|
-          # const_get(:Config) issues a deprecation warning on ruby 1.8.7
-          # TODO: clean up now that we're not supporting Ruby 1.8
-          Object.const_get(const) unless const == :Config
+          # const_get(:TimeoutError) issues a deprecation warning on ruby 2.3.0
+          Object.const_get(const) unless const == :TimeoutError
         end.select do |const|
           const.class == Class && const.respond_to?(:parse)
         end


### PR DESCRIPTION
Fixes #21 

cc @lebogan