### PR TITLE
Allow options that start with a global option name

### DIFF
--- a/lib/commander/runner.rb
+++ b/lib/commander/runner.rb
@@ -339,7 +339,7 @@ module Commander
 
         past_switch, arg_removed = false, false
         args.delete_if do |arg|
-          if switches.any? { |s| arg[0, s.length] == s }
+          if switches.any? { |s| s[0, arg.length] == arg }
             arg_removed = !switch_has_arg
             past_switch = true
           elsif past_switch && !arg_removed && arg !~ /^-/

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -318,6 +318,14 @@ describe Commander do
       command_runner.remove_global_options options, args
       expect(args).to eq(%w(alpha beta))
     end
+
+    it 'should not remove options that start with a global option name' do
+      options, args = [], []
+      options << { switches: ['-v', '--version'] }
+      args << '--versionCode' << 'something'
+      command_runner.remove_global_options options, args
+      expect(args).to eq(%w(--versionCode something))
+    end
   end
 
   describe '--trace' do


### PR DESCRIPTION
Fixes #29 

@mariusmarais I think this should fix the problem you reported.