### PR TITLE
active_command to delegates

### DIFF
--- a/lib/commander/delegates.rb
+++ b/lib/commander/delegates.rb
@@ -8,6 +8,7 @@ module Commander
       global_option
       alias_command
       default_command
+      active_command
       always_trace!
       never_trace!
     ).each do |meth|


### PR DESCRIPTION
I need parse values from args like:

``` ruby
command :test do |c|
   c.option('--files FILES', Array) { |values|
       Commander::Runner.instance.active_command
   }
end
```

It will be much nicer if I use just `active_command`.
