### PR TITLE
Fix Issue 36 - Ignore MissingSourceFile

### DIFF
--- a/lib/commander/user_interaction.rb
+++ b/lib/commander/user_interaction.rb
@@ -330,7 +330,7 @@ module Commander
         # All Classes that respond to #parse
         Object.constants.map do |const|
           # Ignore constants that trigger deprecation warnings
-          Object.const_get(const) unless [:Config, :TimeoutError].include?(const)
+          Object.const_get(const) unless [:Config, :TimeoutError, :MissingSourceFile].include?(const)
         end.select do |const|
           const.class == Class && const.respond_to?(:parse)
         end


### PR DESCRIPTION
The `MissingSourceFile` constant is added to the list of constants to
ignore because of the deprecation warnings that their usage cause.

With ActiveSupport 5+, `MissingSourceFile` has been deprecated and will
now throw warnings.

This is fixes [Issue 36](https://github.com/commander-rb/commander/issues/36)