### PR TITLE
help command - add paging flag

### DIFF
--- a/lib/commander/runner.rb
+++ b/lib/commander/runner.rb
@@ -134,6 +134,7 @@ module Commander
     #   :name            Program name, defaults to basename of executable
     #   :help_formatter  Defaults to Commander::HelpFormatter::Terminal
     #   :help            Allows addition of arbitrary global help blocks
+    #   :help_paging     Flag for toggling help paging
     #   :int_message     Message to display when interrupted (CTRL + C)
     #
 
@@ -147,7 +148,7 @@ module Commander
         @program[key] = block
       else
         unless args.empty?
-          @program[key] = (args.count == 1 && args[0]) || args
+          @program[key] = args.count == 1 ? args[0] : args
         end
         @program[key]
       end
@@ -283,6 +284,7 @@ module Commander
       {
         help_formatter: HelpFormatter::Terminal,
         name: File.basename($PROGRAM_NAME),
+        help_paging: true
       }
     end
 
@@ -297,7 +299,7 @@ module Commander
         c.example 'Display global help', 'command help'
         c.example "Display help for 'foo'", 'command help foo'
         c.when_called do |args, _options|
-          UI.enable_paging
+          UI.enable_paging if program(:help_paging)
           if args.empty?
             say help_formatter.render
           else

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -407,6 +407,23 @@ describe Commander do
     it 'can be used before or after the command and options' do
       expect(run('test', '--help')).to eq("Implement help for test here\n")
     end
+
+    describe 'help_paging program information' do
+      it 'enables paging when enabled' do
+        run('--help') { program :help_paging, true }
+        expect(Commander::UI).to have_received(:enable_paging)
+      end
+
+      it 'is enabled by default' do
+        run('--help')
+        expect(Commander::UI).to have_received(:enable_paging)
+      end
+
+      it 'does not enable paging when disabled' do
+        run('--help') { program :help_paging, false }
+        expect(Commander::UI).not_to have_received(:enable_paging)
+      end
+    end
   end
 
   describe 'with invalid options' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -58,6 +58,7 @@ end
 def run(*args)
   new_command_runner(*args) do
     program :help_formatter, Commander::HelpFormatter::Base
+    yield if block_given?
   end.run!
   @output.string
 end


### PR DESCRIPTION
Adds a flag for toggling `help` command paging behaviour.
It doesn't change the defaults.

Depends on https://github.com/commander-rb/commander/pull/40