### PR TITLE
Update Rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,5 +5,33 @@ Encoding:
   Enabled: false
 
 # Enforce trailing comma after last item of multiline hashes.
-Style/TrailingComma:
+Style/TrailingCommaInLiteral:
   EnforcedStyleForMultiline: comma
+
+Metrics/BlockLength:
+  Enabled: false
+
+Style/SignalException:
+  EnforcedStyle: only_fail
+
+Style/ParallelAssignment:
+  Enabled: false
+
+Style/NumericLiteralPrefix:
+  EnforcedOctalStyle: zero_only
+
+Style/MethodMissing:
+  Enabled: false
+
+Style/SpaceInsideStringInterpolation:
+  Enabled: false
+
+Style/MultilineOperationIndentation:
+  Enabled: false
+
+Style/EmptyMethod:
+  EnforcedStyle: expanded
+
+Metrics/ModuleLength:
+  CountComments: false  # count full line comments?
+  Max: 150

--- a/commander.gemspec
+++ b/commander.gemspec
@@ -22,8 +22,10 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rspec', '~> 3.2')
   s.add_development_dependency('rake')
   s.add_development_dependency('simplecov')
-  s.add_development_dependency('rubocop', '~> 0.29.1')
   if RUBY_VERSION < '2.0'
+    s.add_development_dependency('rubocop', '~> 0.41.1')
     s.add_development_dependency('json', '< 2.0')
+  else
+    s.add_development_dependency('rubocop', '~> 0.46')
   end
 end

--- a/lib/commander/command.rb
+++ b/lib/commander/command.rb
@@ -140,7 +140,7 @@ module Commander
       fail ArgumentError, 'must pass an object, class, or block.' if args.empty? && !block
       @when_called = block ? [block] : args
     end
-    alias_method :action, :when_called
+    alias action when_called
 
     ##
     # Run the command with _args_.

--- a/lib/commander/runner.rb
+++ b/lib/commander/runner.rb
@@ -246,7 +246,7 @@ module Commander
 
     def valid_command_names_from(*args)
       arg_string = args.delete_if { |value| value =~ /^-/ }.join ' '
-      commands.keys.find_all { |name| name if /^#{name}\b/.match arg_string }
+      commands.keys.find_all { |name| name if arg_string =~ /^#{name}\b/ }
     end
 
     ##

--- a/lib/commander/user_interaction.rb
+++ b/lib/commander/user_interaction.rb
@@ -181,7 +181,7 @@ module Commander
           #{statement}
           end if
         end tell
-        ),
+        )
       ).strip.to_sym
     end
 

--- a/lib/commander/version.rb
+++ b/lib/commander/version.rb
@@ -1,3 +1,3 @@
 module Commander
-  VERSION = '4.4.1'
+  VERSION = '4.4.1'.freeze
 end


### PR DESCRIPTION
[Rubocop 0.38](https://github.com/bbatsov/rubocop/releases/tag/v0.38.0) adds Rake 11 compatibility.

This fixes `NoMethodError: undefined method last_comment for #<Rake::Application:>` problem, [Travis](https://travis-ci.org/commander-rb/commander/jobs/182567989#L663)