### PR TITLE
Revise help output with default command

### DIFF
--- a/lib/commander/help_formatters/terminal/help.erb
+++ b/lib/commander/help_formatters/terminal/help.erb
@@ -26,6 +26,17 @@
         <%= option[:description] %>
 	<% end -%>
 <% end -%>
+<% unless @default_command.nil? -%>
+<% default_command = @commands.values.find { |command| command.name == @default_command.to_s } -%>
+<% unless default_command.nil? || default_command.options.empty? %>
+  <%= $terminal.color "OPTIONS", :bold %>:
+	<% for option in default_command.options -%>
+
+    <%= option[:switches].join ', ' %> 
+        <%= option[:description] %>
+	<% end -%>
+<% end -%>
+<% end -%>
 <% if program :help -%>
   <% for title, body in program(:help) %>
   <%= $terminal.color title.to_s.upcase, :bold %>:

--- a/lib/commander/help_formatters/terminal/help.erb
+++ b/lib/commander/help_formatters/terminal/help.erb
@@ -30,8 +30,6 @@
         <%= option[:description] %>
 	<% end -%>
 <% end -%>
-<% unless @default_command.nil? -%>
-<% default_command = @commands.values.find { |command| command.name == @default_command.to_s } -%>
 <% unless default_command.nil? || default_command.options.empty? %>
   <%= $terminal.color "OPTIONS for #{default_command.name}", :bold %>:
 	<% for option in default_command.options -%>
@@ -39,7 +37,6 @@
     <%= option[:switches].join ', ' %> 
         <%= option[:description] %>
 	<% end -%>
-<% end -%>
 <% end -%>
 <% if program :help -%>
   <% for title, body in program(:help) %>

--- a/lib/commander/help_formatters/terminal/help.erb
+++ b/lib/commander/help_formatters/terminal/help.erb
@@ -1,5 +1,5 @@
 <% unless @default_command.nil? -%>
-  <% default_command = @commands.values.find { |command| command.name == @default_command.to_s } -%>
+<% default_command = @commands.values.find { |command| command.name == @default_command.to_s } -%>
 <% end -%>
   <%= $terminal.color "NAME", :bold %>:
 

--- a/lib/commander/help_formatters/terminal/help.erb
+++ b/lib/commander/help_formatters/terminal/help.erb
@@ -1,6 +1,3 @@
-<% unless @default_command.nil? -%>
-<% default_command = @commands.values.find { |command| command.name == @default_command.to_s } -%>
-<% end -%>
   <%= $terminal.color "NAME", :bold %>:
 
     <%= program :name %>
@@ -9,11 +6,10 @@
 
     <%= Commander::HelpFormatter.indent 4, program(:description) %>
 
-  <%= "%s: %s" % [$terminal.color("COMMANDS", :bold), default_command.nil? ? '' : '(* default)'] %>
+  <%= "#{$terminal.color "COMMANDS", :bold}:#{default_command_description}" %>
 <% for name, command in @commands.sort -%>
 	<% unless alias? name %>
-    <% summary_prefix = (!default_command.nil? && command.name == default_command.name)? '* ' : '  ' -%>
-    <%= "%-#{max_command_length}s #{summary_prefix}%s" % [command.name, command.summary || command.description] -%>
+    <%= "%-#{max_command_length}s #{summary_prefix(command.name)}%s" % [command.name, command.summary || command.description] -%>
 	<% end -%>
 <% end %>
 <% unless @aliases.empty? %>
@@ -30,9 +26,9 @@
         <%= option[:description] %>
 	<% end -%>
 <% end -%>
-<% unless default_command.nil? || default_command.options.empty? %>
-  <%= $terminal.color "OPTIONS for #{default_command.name}", :bold %>:
-	<% for option in default_command.options -%>
+<% unless @default_command_options.empty? %>
+  <%= $terminal.color "OPTIONS for #{@default_command}", :bold %>:
+	<% for option in @default_command_options -%>
 
     <%= option[:switches].join ', ' %> 
         <%= option[:description] %>

--- a/lib/commander/help_formatters/terminal/help.erb
+++ b/lib/commander/help_formatters/terminal/help.erb
@@ -1,3 +1,6 @@
+<% unless @default_command.nil? -%>
+  <% default_command = @commands.values.find { |command| command.name == @default_command.to_s } -%>
+<% end -%>
   <%= $terminal.color "NAME", :bold %>:
 
     <%= program :name %>
@@ -6,10 +9,11 @@
 
     <%= Commander::HelpFormatter.indent 4, program(:description) %>
 
-  <%= $terminal.color "COMMANDS", :bold %>:
+  <%= "%s: %s" % [$terminal.color("COMMANDS", :bold), default_command.nil? ? '' : '(* default)'] %>
 <% for name, command in @commands.sort -%>
 	<% unless alias? name %>
-    <%= "%-#{max_command_length}s %s" % [command.name, command.summary || command.description] -%>
+    <% summary_prefix = (!default_command.nil? && command.name == default_command.name)? '* ' : '  ' -%>
+    <%= "%-#{max_command_length}s #{summary_prefix}%s" % [command.name, command.summary || command.description] -%>
 	<% end -%>
 <% end %>
 <% unless @aliases.empty? %>
@@ -29,7 +33,7 @@
 <% unless @default_command.nil? -%>
 <% default_command = @commands.values.find { |command| command.name == @default_command.to_s } -%>
 <% unless default_command.nil? || default_command.options.empty? %>
-  <%= $terminal.color "OPTIONS", :bold %>:
+  <%= $terminal.color "OPTIONS for #{default_command.name}", :bold %>:
 	<% for option in default_command.options -%>
 
     <%= option[:switches].join ', ' %> 

--- a/lib/commander/help_formatters/terminal/help.erb
+++ b/lib/commander/help_formatters/terminal/help.erb
@@ -26,7 +26,7 @@
         <%= option[:description] %>
 	<% end -%>
 <% end -%>
-<% unless @default_command_options.empty? %>
+<% unless default_command_options.empty? %>
   <%= $terminal.color "OPTIONS for #{@default_command}", :bold %>:
 	<% for option in @default_command_options -%>
 

--- a/lib/commander/help_formatters/terminal_compact/help.erb
+++ b/lib/commander/help_formatters/terminal_compact/help.erb
@@ -1,15 +1,11 @@
-<% unless @default_command.nil? -%>
-<% default_command = @commands.values.find { |command| command.name == @default_command.to_s } -%>
-<% end -%>
   <%= program :name %>
 
   <%= program :description %>
 
-  <%= "Commands: %s" % [default_command.nil? ? '' : '(* default)'] %>
+  <%= "Commands:#{default_command_description}" %>
 <% for name, command in @commands.sort -%>
 <% unless alias? name -%>
-    <% summary_prefix = (!default_command.nil? && command.name == default_command.name)? '* ' : '  ' -%>
-    <%= "%-#{max_command_length}s #{summary_prefix}%s" % [command.name, command.summary || command.description] %>
+    <%= "%-#{max_command_length}s #{summary_prefix(command.name)}%s" % [command.name, command.summary || command.description] %>
 <% end -%>
 <% end -%>
 <% unless @aliases.empty? %>
@@ -24,9 +20,9 @@
     <%= "%-20s %s" % [option[:switches].join(', '), option[:description]] -%> 
 <% end -%>
 <% end -%>
-<% unless default_command.nil? || default_command.options.empty? %>
-  <%= "Options for #{default_command.name}:" %>
-<% for option in default_command.options -%>
+<% unless @default_command_options.empty? %>
+  <%= "Options for #{@default_command}:" %>
+<% for option in @default_command_options -%>
     <%= "%-20s %s" % [option[:switches].join(', '), option[:description]] %>
 <% end -%>
 <% end -%>

--- a/lib/commander/help_formatters/terminal_compact/help.erb
+++ b/lib/commander/help_formatters/terminal_compact/help.erb
@@ -25,7 +25,7 @@
 <% end -%>
 <% end -%>
 <% unless default_command.nil? || default_command.options.empty? %>
-  Options:
+  <%= "Options for #{default_command.name}:" %>
 <% for option in default_command.options -%>
     <%= "%-20s %s" % [option[:switches].join(', '), option[:description]] %>
 <% end -%>

--- a/lib/commander/help_formatters/terminal_compact/help.erb
+++ b/lib/commander/help_formatters/terminal_compact/help.erb
@@ -1,3 +1,6 @@
+<% unless @default_command.nil? -%>
+  <% default_command = @commands.values.find { |command| command.name == @default_command.to_s } -%>
+<% end -%>
   <%= program :name %>
 
   <%= program :description %>
@@ -20,13 +23,10 @@
     <%= "%-20s %s" % [option[:switches].join(', '), option[:description]] -%> 
 <% end -%>
 <% end -%>
-<% unless @default_command.nil? -%>
-<% default_command = @commands.values.find { |command| command.name == @default_command.to_s } -%>
 <% unless default_command.nil? || default_command.options.empty? %>
   Options:
 <% for option in default_command.options -%>
     <%= "%-20s %s" % [option[:switches].join(', '), option[:description]] %>
-<% end -%>
 <% end -%>
 <% end -%>
 <% if program :help -%>

--- a/lib/commander/help_formatters/terminal_compact/help.erb
+++ b/lib/commander/help_formatters/terminal_compact/help.erb
@@ -5,7 +5,7 @@
 
   <%= program :description %>
 
-  Commands:
+  <%= "Commands: %s" % [default_command.nil? ? '' : '(* default)'] %>
 <% for name, command in @commands.sort -%>
 <% unless alias? name -%>
     <% summary_prefix = (!default_command.nil? && command.name == default_command.name)? '* ' : '  ' -%>

--- a/lib/commander/help_formatters/terminal_compact/help.erb
+++ b/lib/commander/help_formatters/terminal_compact/help.erb
@@ -1,5 +1,5 @@
 <% unless @default_command.nil? -%>
-  <% default_command = @commands.values.find { |command| command.name == @default_command.to_s } -%>
+<% default_command = @commands.values.find { |command| command.name == @default_command.to_s } -%>
 <% end -%>
   <%= program :name %>
 

--- a/lib/commander/help_formatters/terminal_compact/help.erb
+++ b/lib/commander/help_formatters/terminal_compact/help.erb
@@ -20,7 +20,7 @@
     <%= "%-20s %s" % [option[:switches].join(', '), option[:description]] -%> 
 <% end -%>
 <% end -%>
-<% unless @default_command_options.empty? %>
+<% unless default_command_options.empty? %>
   <%= "Options for #{@default_command}:" %>
 <% for option in @default_command_options -%>
     <%= "%-20s %s" % [option[:switches].join(', '), option[:description]] %>

--- a/lib/commander/help_formatters/terminal_compact/help.erb
+++ b/lib/commander/help_formatters/terminal_compact/help.erb
@@ -20,6 +20,15 @@
     <%= "%-20s %s" % [option[:switches].join(', '), option[:description]] -%> 
 <% end -%>
 <% end -%>
+<% unless @default_command.nil? -%>
+<% default_command = @commands.values.find { |command| command.name == @default_command.to_s } -%>
+<% unless default_command.nil? || default_command.options.empty? %>
+  Options:
+<% for option in default_command.options -%>
+    <%= "%-20s %s" % [option[:switches].join(', '), option[:description]] %>
+<% end -%>
+<% end -%>
+<% end -%>
 <% if program :help -%>
   <% for title, body in program(:help) %>
   <%= title %>:

--- a/lib/commander/help_formatters/terminal_compact/help.erb
+++ b/lib/commander/help_formatters/terminal_compact/help.erb
@@ -8,7 +8,8 @@
   Commands:
 <% for name, command in @commands.sort -%>
 <% unless alias? name -%>
-    <%= "%-#{max_command_length}s %s" % [command.name, command.summary || command.description] %>
+    <% summary_prefix = (!default_command.nil? && command.name == default_command.name)? '* ' : '  ' -%>
+    <%= "%-#{max_command_length}s #{summary_prefix}%s" % [command.name, command.summary || command.description] %>
 <% end -%>
 <% end -%>
 <% unless @aliases.empty? %>

--- a/lib/commander/runner.rb
+++ b/lib/commander/runner.rb
@@ -203,7 +203,6 @@ module Commander
 
     def default_command(name)
       @default_command = name
-      default_command_options
     end
 
     ##

--- a/lib/commander/runner.rb
+++ b/lib/commander/runner.rb
@@ -29,7 +29,8 @@ module Commander
     # supplying _args_ for mocking, or arbitrary usage.
 
     def initialize(args = ARGV)
-      @args, @commands, @aliases, @options = args, {}, {}, []
+      @args, @commands, @aliases, @options,
+        @default_command_options = args, {}, {}, [], []
       @help_formatter_aliases = help_formatter_alias_defaults
       @program = program_defaults
       @always_trace = false
@@ -202,6 +203,36 @@ module Commander
 
     def default_command(name)
       @default_command = name
+      default_command_options
+    end
+
+    ##
+    # Description about mark for default_command
+
+    def default_command_description
+      return ' (* default)' if @default_command
+      ''
+    end
+
+    ##
+    # Prefix for summary to identify default_command easily.
+
+    def summary_prefix(name)
+      return '' if @default_command.nil?
+      return '* ' if name == @default_command.to_s
+      '  '
+    end
+
+    ##
+    # Options of default_command.
+
+    def default_command_options
+      return [] if @commands.empty?
+
+      default_command = @commands.values.find { |command| command.name == @default_command.to_s }
+      return [] if default_command.nil?
+
+      @default_command_options = default_command.options
     end
 
     ##

--- a/spec/help_formatters/terminal_compact_spec.rb
+++ b/spec/help_formatters/terminal_compact_spec.rb
@@ -66,7 +66,7 @@ describe Commander::HelpFormatter::TerminalCompact do
         end
 
         it 'the options label' do
-          expect(@global_help).to include('  Options')
+          expect(@global_help).to include('Options for install gem')
         end
 
         it 'the command options' do
@@ -105,7 +105,7 @@ describe Commander::HelpFormatter::TerminalCompact do
 
       describe 'should not display' do
         it 'the options label' do
-          expect(@global_help).not_to include('  Options')
+          expect(@global_help).not_to include('Options for install gem')
         end
       end
     end

--- a/spec/help_formatters/terminal_compact_spec.rb
+++ b/spec/help_formatters/terminal_compact_spec.rb
@@ -119,7 +119,6 @@ describe Commander::HelpFormatter::TerminalCompact do
           end
         end
       end
-
     end
 
     describe 'without command option' do

--- a/spec/help_formatters/terminal_compact_spec.rb
+++ b/spec/help_formatters/terminal_compact_spec.rb
@@ -28,6 +28,12 @@ describe Commander::HelpFormatter::TerminalCompact do
         expect(@global_help).to include('Install some gem')
       end
     end
+
+    describe 'should not display' do
+      it 'the commands label with description for default_command' do
+        expect(@global_help).not_to include('Commands: (* default)')
+      end
+    end
   end
 
   describe 'global help with default_command' do
@@ -47,6 +53,10 @@ describe Commander::HelpFormatter::TerminalCompact do
       end
 
       describe 'should display' do
+        it 'the commands label with description for default_command' do
+          expect(@global_help).to include('Commands: (* default)')
+        end
+
         it 'the command name' do
           expect(@global_help).to include('install gem')
         end
@@ -80,6 +90,10 @@ describe Commander::HelpFormatter::TerminalCompact do
       end
 
       describe 'should display' do
+        it 'the commands label with description for default_command' do
+          expect(@global_help).to include('Commands: (* default)')
+        end
+
         it 'the command name' do
           expect(@global_help).to include('install gem')
         end

--- a/spec/help_formatters/terminal_compact_spec.rb
+++ b/spec/help_formatters/terminal_compact_spec.rb
@@ -27,6 +27,10 @@ describe Commander::HelpFormatter::TerminalCompact do
       it 'the summary' do
         expect(@global_help).to include('Install some gem')
       end
+
+      it 'one space between command name and summary' do
+        expect(@global_help).to include('install gem Install some gem')
+      end
     end
 
     describe 'should not display' do

--- a/spec/help_formatters/terminal_compact_spec.rb
+++ b/spec/help_formatters/terminal_compact_spec.rb
@@ -30,6 +30,73 @@ describe Commander::HelpFormatter::TerminalCompact do
     end
   end
 
+  describe 'global help with default_command' do
+    describe 'with command option' do
+      before :each do
+        new_command_runner 'help' do
+          program :help_formatter, :compact
+          command :'install gem' do |c|
+            c.syntax = 'foo install gem [options]'
+            c.summary = 'Install some gem'
+            c.option('--testing-command', 'Testing command')
+            c.option('--testing-command-second', 'Testing command second')
+          end
+          default_command :'install gem'
+        end.run!
+        @global_help = @output.string
+      end
+
+      describe 'should display' do
+        it 'the command name' do
+          expect(@global_help).to include('install gem')
+        end
+
+        it 'the summary' do
+          expect(@global_help).to include('Install some gem')
+        end
+
+        it 'the options label' do
+          expect(@global_help).to include('  Options')
+        end
+
+        it 'the command options' do
+          expect(@global_help).to include('--testing-command')
+          expect(@global_help).to include('--testing-command-second')
+        end
+      end
+    end
+
+    describe 'without command option' do
+      before :each do
+        new_command_runner 'help' do
+          program :help_formatter, :compact
+          command :'install gem' do |c|
+            c.syntax = 'foo install gem [options]'
+            c.summary = 'Install some gem'
+          end
+          default_command :'install gem'
+        end.run!
+        @global_help = @output.string
+      end
+
+      describe 'should display' do
+        it 'the command name' do
+          expect(@global_help).to include('install gem')
+        end
+
+        it 'the summary' do
+          expect(@global_help).to include('Install some gem')
+        end
+      end
+
+      describe 'should not display' do
+        it 'the options label' do
+          expect(@global_help).not_to include('  Options')
+        end
+      end
+    end
+  end
+
   describe 'command help' do
     before :each do
       new_command_runner 'help', 'install', 'gem' do

--- a/spec/help_formatters/terminal_compact_spec.rb
+++ b/spec/help_formatters/terminal_compact_spec.rb
@@ -42,42 +42,84 @@ describe Commander::HelpFormatter::TerminalCompact do
 
   describe 'global help with default_command' do
     describe 'with command option' do
-      before :each do
-        new_command_runner 'help' do
-          program :help_formatter, :compact
-          command :'install gem' do |c|
-            c.syntax = 'foo install gem [options]'
-            c.summary = 'Install some gem'
-            c.option('--testing-command', 'Testing command')
-            c.option('--testing-command-second', 'Testing command second')
+      describe 'default_command is before command' do
+        before :each do
+          new_command_runner 'help' do
+            program :help_formatter, :compact
+            default_command :'install gem'
+            command :'install gem' do |c|
+              c.syntax = 'foo install gem [options]'
+              c.summary = 'Install some gem'
+              c.option('--testing-command', 'Testing command')
+              c.option('--testing-command-second', 'Testing command second')
+            end
+          end.run!
+          @global_help = @output.string
+        end
+
+        describe 'should display' do
+          it 'the commands label with description for default_command' do
+            expect(@global_help).to include('Commands: (* default)')
           end
-          default_command :'install gem'
-        end.run!
-        @global_help = @output.string
-      end
 
-      describe 'should display' do
-        it 'the commands label with description for default_command' do
-          expect(@global_help).to include('Commands: (* default)')
-        end
+          it 'the command name' do
+            expect(@global_help).to include('install gem')
+          end
 
-        it 'the command name' do
-          expect(@global_help).to include('install gem')
-        end
+          it 'the summary with marked as default_command' do
+            expect(@global_help).to include('* Install some gem')
+          end
 
-        it 'the summary with marked as default_command' do
-          expect(@global_help).to include('* Install some gem')
-        end
+          it 'the options label' do
+            expect(@global_help).to include('Options for install gem')
+          end
 
-        it 'the options label' do
-          expect(@global_help).to include('Options for install gem')
-        end
-
-        it 'the command options' do
-          expect(@global_help).to include('--testing-command')
-          expect(@global_help).to include('--testing-command-second')
+          it 'the command options' do
+            expect(@global_help).to include('--testing-command')
+            expect(@global_help).to include('--testing-command-second')
+          end
         end
       end
+
+      describe 'default_command is after command' do
+        before :each do
+          new_command_runner 'help' do
+            program :help_formatter, :compact
+            command :'install gem' do |c|
+              c.syntax = 'foo install gem [options]'
+              c.summary = 'Install some gem'
+              c.option('--testing-command', 'Testing command')
+              c.option('--testing-command-second', 'Testing command second')
+            end
+            default_command :'install gem'
+          end.run!
+          @global_help = @output.string
+        end
+
+        describe 'should display' do
+          it 'the commands label with description for default_command' do
+            expect(@global_help).to include('Commands: (* default)')
+          end
+
+          it 'the command name' do
+            expect(@global_help).to include('install gem')
+          end
+
+          it 'the summary with marked as default_command' do
+            expect(@global_help).to include('* Install some gem')
+          end
+
+          it 'the options label' do
+            expect(@global_help).to include('Options for install gem')
+          end
+
+          it 'the command options' do
+            expect(@global_help).to include('--testing-command')
+            expect(@global_help).to include('--testing-command-second')
+          end
+        end
+      end
+
     end
 
     describe 'without command option' do

--- a/spec/help_formatters/terminal_compact_spec.rb
+++ b/spec/help_formatters/terminal_compact_spec.rb
@@ -51,8 +51,8 @@ describe Commander::HelpFormatter::TerminalCompact do
           expect(@global_help).to include('install gem')
         end
 
-        it 'the summary' do
-          expect(@global_help).to include('Install some gem')
+        it 'the summary with marked as default_command' do
+          expect(@global_help).to include('* Install some gem')
         end
 
         it 'the options label' do
@@ -85,7 +85,7 @@ describe Commander::HelpFormatter::TerminalCompact do
         end
 
         it 'the summary' do
-          expect(@global_help).to include('Install some gem')
+          expect(@global_help).to include('* Install some gem')
         end
       end
 

--- a/spec/help_formatters/terminal_spec.rb
+++ b/spec/help_formatters/terminal_spec.rb
@@ -26,6 +26,10 @@ describe Commander::HelpFormatter::Terminal do
       it 'the summary' do
         expect(@global_help).to include('Install some gem')
       end
+
+      it 'one space between command name and summary' do
+        expect(@global_help).to include('install gem Install some gem')
+      end
     end
 
     describe 'should not display' do

--- a/spec/help_formatters/terminal_spec.rb
+++ b/spec/help_formatters/terminal_spec.rb
@@ -27,6 +27,12 @@ describe Commander::HelpFormatter::Terminal do
         expect(@global_help).to include('Install some gem')
       end
     end
+
+    describe 'should not display' do
+      it 'the commands label with description for default_command' do
+        expect(@global_help).not_to include("COMMANDS\e[0m: (* default)")
+      end
+    end
   end
 
   describe 'global help with default_command' do
@@ -45,16 +51,20 @@ describe Commander::HelpFormatter::Terminal do
       end
 
       describe 'should display' do
+        it 'the commands label with description for default_command' do
+          expect(@global_help).to include("COMMANDS\e[0m: (* default)")
+        end
+
         it 'the command name' do
           expect(@global_help).to include('install gem')
         end
 
-        it 'the summary' do
-          expect(@global_help).to include('Install some gem')
+        it 'the summary with marked as default_command' do
+          expect(@global_help).to include('* Install some gem')
         end
 
         it 'the options label' do
-          expect(@global_help).to include('mOPTIONS')
+          expect(@global_help).to include('OPTIONS for install gem')
         end
 
         it 'the command options' do
@@ -77,18 +87,22 @@ describe Commander::HelpFormatter::Terminal do
       end
 
       describe 'should display' do
+        it 'the commands label with description for default_command' do
+          expect(@global_help).to include("COMMANDS\e[0m: (* default)")
+        end
+
         it 'the command name' do
           expect(@global_help).to include('install gem')
         end
 
         it 'the summary' do
-          expect(@global_help).to include('Install some gem')
+          expect(@global_help).to include('* Install some gem')
         end
       end
 
       describe 'should not display' do
         it 'the options label' do
-          expect(@global_help).not_to include('mOPTIONS')
+          expect(@global_help).not_to include('OPTIONS for install gem')
         end
       end
     end

--- a/spec/help_formatters/terminal_spec.rb
+++ b/spec/help_formatters/terminal_spec.rb
@@ -29,6 +29,71 @@ describe Commander::HelpFormatter::Terminal do
     end
   end
 
+  describe 'global help with default_command' do
+    describe 'with command option' do
+      before :each do
+        new_command_runner 'help' do
+          command :'install gem' do |c|
+            c.syntax = 'foo install gem [options]'
+            c.summary = 'Install some gem'
+            c.option('--testing-command', 'Testing command')
+            c.option('--testing-command-second', 'Testing command second')
+          end
+          default_command :'install gem'
+        end.run!
+        @global_help = @output.string
+      end
+
+      describe 'should display' do
+        it 'the command name' do
+          expect(@global_help).to include('install gem')
+        end
+
+        it 'the summary' do
+          expect(@global_help).to include('Install some gem')
+        end
+
+        it 'the options label' do
+          expect(@global_help).to include('mOPTIONS')
+        end
+
+        it 'the command options' do
+          expect(@global_help).to include('--testing-command')
+          expect(@global_help).to include('--testing-command-second')
+        end
+      end
+    end
+
+    describe 'without command option' do
+      before :each do
+        new_command_runner 'help' do
+          command :'install gem' do |c|
+            c.syntax = 'foo install gem [options]'
+            c.summary = 'Install some gem'
+          end
+          default_command :'install gem'
+        end.run!
+        @global_help = @output.string
+      end
+
+      describe 'should display' do
+        it 'the command name' do
+          expect(@global_help).to include('install gem')
+        end
+
+        it 'the summary' do
+          expect(@global_help).to include('Install some gem')
+        end
+      end
+
+      describe 'should not display' do
+        it 'the options label' do
+          expect(@global_help).not_to include('mOPTIONS')
+        end
+      end
+    end
+  end
+
   describe 'command help' do
     before :each do
       new_command_runner 'help', 'install', 'gem' do

--- a/spec/help_formatters/terminal_spec.rb
+++ b/spec/help_formatters/terminal_spec.rb
@@ -41,39 +41,79 @@ describe Commander::HelpFormatter::Terminal do
 
   describe 'global help with default_command' do
     describe 'with command option' do
-      before :each do
-        new_command_runner 'help' do
-          command :'install gem' do |c|
-            c.syntax = 'foo install gem [options]'
-            c.summary = 'Install some gem'
-            c.option('--testing-command', 'Testing command')
-            c.option('--testing-command-second', 'Testing command second')
+      describe 'default_command is before command' do
+        before :each do
+          new_command_runner 'help' do
+            default_command :'install gem'
+            command :'install gem' do |c|
+              c.syntax = 'foo install gem [options]'
+              c.summary = 'Install some gem'
+              c.option('--testing-command', 'Testing command')
+              c.option('--testing-command-second', 'Testing command second')
+            end
+          end.run!
+          @global_help = @output.string
+        end
+
+        describe 'should display' do
+          it 'the commands label with description for default_command' do
+            expect(@global_help).to include("COMMANDS\e[0m: (* default)")
           end
-          default_command :'install gem'
-        end.run!
-        @global_help = @output.string
+
+          it 'the command name' do
+            expect(@global_help).to include('install gem')
+          end
+
+          it 'the summary with marked as default_command' do
+            expect(@global_help).to include('* Install some gem')
+          end
+
+          it 'the options label' do
+            expect(@global_help).to include('OPTIONS for install gem')
+          end
+
+          it 'the command options' do
+            expect(@global_help).to include('--testing-command')
+            expect(@global_help).to include('--testing-command-second')
+          end
+        end
       end
 
-      describe 'should display' do
-        it 'the commands label with description for default_command' do
-          expect(@global_help).to include("COMMANDS\e[0m: (* default)")
+      describe 'default_command is after command' do
+        before :each do
+          new_command_runner 'help' do
+            command :'install gem' do |c|
+              c.syntax = 'foo install gem [options]'
+              c.summary = 'Install some gem'
+              c.option('--testing-command', 'Testing command')
+              c.option('--testing-command-second', 'Testing command second')
+            end
+            default_command :'install gem'
+          end.run!
+          @global_help = @output.string
         end
 
-        it 'the command name' do
-          expect(@global_help).to include('install gem')
-        end
+        describe 'should display' do
+          it 'the commands label with description for default_command' do
+            expect(@global_help).to include("COMMANDS\e[0m: (* default)")
+          end
 
-        it 'the summary with marked as default_command' do
-          expect(@global_help).to include('* Install some gem')
-        end
+          it 'the command name' do
+            expect(@global_help).to include('install gem')
+          end
 
-        it 'the options label' do
-          expect(@global_help).to include('OPTIONS for install gem')
-        end
+          it 'the summary with marked as default_command' do
+            expect(@global_help).to include('* Install some gem')
+          end
 
-        it 'the command options' do
-          expect(@global_help).to include('--testing-command')
-          expect(@global_help).to include('--testing-command-second')
+          it 'the options label' do
+            expect(@global_help).to include('OPTIONS for install gem')
+          end
+
+          it 'the command options' do
+            expect(@global_help).to include('--testing-command')
+            expect(@global_help).to include('--testing-command-second')
+          end
         end
       end
     end


### PR DESCRIPTION
@ggilder Thank you for maintaining great gem. 😄 

### Description
<!--- Describe your changes in detail -->

Add details information about default_command to help output.
You can see sample outputs with rspec.

#### Commander::HelpFormatter::TerminalCompact

<details>
<summary>global help</summary>

https://github.com/nafu/commander/blob/06283baedce0db38d40e7dc28af8561751648ab6/spec/help_formatters/terminal_compact_spec.rb#L12

```
  test

  something

  Commands:
        help          Display global or [command] help documentation
        install gem   Install some gem
        test          test description

  Global Options:
    -h, --help           Display help documentation
    -v, --version        Display version information
    -t, --trace          Display backtrace when an error occurs
```

</details>

<details>
<summary>global help with default_command</summary>

https://github.com/nafu/commander/blob/06283baedce0db38d40e7dc28af8561751648ab6/spec/help_formatters/terminal_compact_spec.rb#L42

```
  test

  something

  Commands: (* default)
        help          Display global or [command] help documentation
        install gem * Install some gem
        test          test description

  Global Options:
    -h, --help           Display help documentation
    -v, --version        Display version information
    -t, --trace          Display backtrace when an error occurs

  Options for install gem:
    --testing-command    Testing command
    --testing-command-second Testing command second
```

</details>

<details>
<summary>global help with default_command that has not command option</summary>

https://github.com/nafu/commander/blob/06283baedce0db38d40e7dc28af8561751648ab6/spec/help_formatters/terminal_compact_spec.rb#L81

```
  test

  something

  Commands: (* default)
        help          Display global or [command] help documentation
        install gem * Install some gem
        test          test description

  Global Options:
    -h, --help           Display help documentation
    -v, --version        Display version information
    -t, --trace          Display backtrace when an error occurs
```

</details>

#### Commander::HelpFormatter::Terminal

<details>
<summary>global help</summary>

https://github.com/nafu/commander/blob/06283baedce0db38d40e7dc28af8561751648ab6/spec/help_formatters/terminal_spec.rb#L12

```
  NAME:

    test

  DESCRIPTION:

    something

  COMMANDS:

        help          Display global or [command] help documentation
        install gem   Install some gem
        test          test description

  GLOBAL OPTIONS:

    -h, --help
        Display help documentation

    -v, --version
        Display version information

    -t, --trace
        Display backtrace when an error occurs
```

</details>

<details>
<summary>global help with default_command that has command option</summary>

https://github.com/nafu/commander/blob/06283baedce0db38d40e7dc28af8561751648ab6/spec/help_formatters/terminal_spec.rb#L41

```
  NAME:

    test

  DESCRIPTION:

    something

  COMMANDS: (* default)

        help          Display global or [command] help documentation
        install gem * Install some gem
        test          test description

  GLOBAL OPTIONS:

    -h, --help
        Display help documentation

    -v, --version
        Display version information

    -t, --trace
        Display backtrace when an error occurs

  OPTIONS for install gem:

    --testing-command
        Testing command

    --testing-command-second
        Testing command second

```

</details>

<details>
<summary>global help with default_command that has not command option</summary>

https://github.com/nafu/commander/blob/06283baedce0db38d40e7dc28af8561751648ab6/spec/help_formatters/terminal_spec.rb#L79

```
  NAME:

    test

  DESCRIPTION:

    something

  COMMANDS: (* default)

        help          Display global or [command] help documentation
        install gem * Install some gem
        test          test description

  GLOBAL OPTIONS:

    -h, --help
        Display help documentation

    -v, --version
        Display version information

    -t, --trace
        Display backtrace when an error occurs
```

</details>

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Even if you set default_command, the help command does not show the information about default_command.
It is very helpful that you can see the default_command and its options with help command. 🚀 

<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Please describe in detail how you tested your changes. --->

I updated not only erb files but rspec so that you can make sure this behavior.
