### PR TITLE
Command Explanation

### DIFF
--- a/lib/commander/command.rb
+++ b/lib/commander/command.rb
@@ -2,7 +2,7 @@ require 'optparse'
 
 module Commander
   class Command
-    attr_accessor :name, :examples, :syntax, :description
+    attr_accessor :name, :examples, :syntax, :description, :explanation
     attr_accessor :summary, :proxy_options, :options
 
     ##

--- a/lib/commander/help_formatters/terminal/command_help.erb
+++ b/lib/commander/help_formatters/terminal/command_help.erb
@@ -14,6 +14,13 @@
 
     <%= Commander::HelpFormatter.indent 4, (@description || @summary || 'No description.') -%>
 
+<% if @explanation -%>
+
+  <%= $terminal.color "EXPLANATION", :bold %>:
+
+    <%= Commander::HelpFormatter.indent 4, (@explanation || 'No explanation.') -%>
+
+<% end -%>
 <% unless @examples.empty? -%>
 
   <%= $terminal.color "EXAMPLES", :bold %>:
@@ -28,8 +35,7 @@
   <%= $terminal.color "OPTIONS", :bold %>:
 	<% for option in @options -%>
 
-    <%= option[:switches].join ', ' %> 
+    <%= option[:switches].join ', ' %>
         <%= Commander::HelpFormatter.indent 8, option[:description] %>
 	<% end -%>
 <% end -%>
-

--- a/lib/commander/help_formatters/terminal_compact/command_help.erb
+++ b/lib/commander/help_formatters/terminal_compact/command_help.erb
@@ -8,6 +8,10 @@
 
   <%= @description || @summary %>
 <% end -%>
+<% if @explanation -%>
+
+  <%= @explanation %>
+<% end -%>
 <% unless @examples.empty? -%>
 
   Examples:
@@ -21,7 +25,6 @@
 
   Options:
 <% for option in @options -%>
-    <%= "%-20s %s" % [option[:switches].join(', '), option[:description]] %> 
+    <%= "%-20s %s" % [option[:switches].join(', '), option[:description]] %>
 <% end -%>
 <% end -%>
-

--- a/spec/help_formatters/terminal_compact_spec.rb
+++ b/spec/help_formatters/terminal_compact_spec.rb
@@ -38,6 +38,7 @@ describe Commander::HelpFormatter::TerminalCompact do
           c.syntax = 'foo install gem [options]'
           c.summary = 'Install some gem'
           c.description = 'Install some gem, blah blah blah'
+          c.explanation = 'This can go way further in describing'
           c.example 'one', 'two'
           c.example 'three', 'four'
         end
@@ -52,6 +53,10 @@ describe Commander::HelpFormatter::TerminalCompact do
 
       it 'the description' do
         expect(@command_help).to include('Install some gem, blah blah blah')
+      end
+
+      it 'the explanation' do
+        expect(@command_help).to include('This can go way further in describing')
       end
 
       it 'all examples' do

--- a/spec/help_formatters/terminal_spec.rb
+++ b/spec/help_formatters/terminal_spec.rb
@@ -36,6 +36,7 @@ describe Commander::HelpFormatter::Terminal do
           c.syntax = 'foo install gem [options]'
           c.summary = 'Install some gem'
           c.description = 'Install some gem, blah blah blah'
+          c.explanation = 'This can go way further in describing'
           c.example 'one', 'two'
           c.example 'three', 'four'
         end
@@ -50,6 +51,10 @@ describe Commander::HelpFormatter::Terminal do
 
       it 'the description' do
         expect(@command_help).to include('Install some gem, blah blah blah')
+      end
+
+      it 'the explanation' do
+        expect(@command_help).to include('This can go way further in describing')
       end
 
       it 'all examples' do


### PR DESCRIPTION
**Description**

Add an extra section to the command help but not to the program help, by adding an attribute `:explanation` to the Commander::Command class.

**Motivation**

Working with Commander on a project, we have a command that can be difficult to understand in some aspect and we wanted a way to go in depth in the help of said command. The issue we faced was that putting too much text into the Command.description was cluttering the program help menu. We could have used the Command.examples section; but this feels more like a workaround than an actual solution.
This is why we suggest to add an extra attribute to the command so that it is possible to be as lengthy as desired and keep a clean program help!

I've added some examples to the spec even though the feature is really simple!

In any case, thanks to anyone working on maintaining and improving this fantastic gem 😃 