### PR TITLE
Fix Ruby 2.5.0 warning; add latest Rubies to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+cache: bundler
 before_install:
   - gem update --system
   - gem update bundler
@@ -6,7 +7,8 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1.10
-  - 2.2.6
-  - 2.3.3
-  - 2.4.0
+  - 2.2.9
+  - 2.3.6
+  - 2.4.3
+  - 2.5.0
   - jruby-19mode

--- a/commander.gemspec
+++ b/commander.gemspec
@@ -27,6 +27,6 @@ Gem::Specification.new do |s|
     s.add_development_dependency('rubocop', '~> 0.41.1')
     s.add_development_dependency('json', '< 2.0')
   else
-    s.add_development_dependency('rubocop', '~> 0.46')
+    s.add_development_dependency('rubocop', '~> 0.49.1')
   end
 end

--- a/lib/commander/user_interaction.rb
+++ b/lib/commander/user_interaction.rb
@@ -324,7 +324,7 @@ module Commander
     # Implements ask_for_CLASS methods.
 
     module AskForClass
-      DEPRECATED_CONSTANTS = [:Config, :TimeoutError, :MissingSourceFile, :NIL, :TRUE, :FALSE, :Fixnum, :Bignum].freeze
+      DEPRECATED_CONSTANTS = [:Config, :TimeoutError, :MissingSourceFile, :NIL, :TRUE, :FALSE, :Fixnum, :Bignum, :Data].freeze
       # All special cases in HighLine::Question#convert, except those that implement #parse
       (
         [Float, Integer, String, Symbol, Regexp, Array, File, Pathname] +


### PR DESCRIPTION
This PR fixes the following warning on Ruby 2.5.0:

> commander-4.4.3/lib/commander/user_interaction.rb:334: warning: constant ::Data is deprecated

Also:

* Add Ruby 2.5.0 to Travis
* Change other Travis Rubies to their latest patch versions
* Enable Bundler cache on Travis
* Pin RuboCop at 0.49 (0.50 and above don't support Ruby 1.9 syntax)

Fixes #61 