### PR TITLE
Avoid deprecation warnings on load

### DIFF
--- a/spec/methods_spec.rb
+++ b/spec/methods_spec.rb
@@ -6,8 +6,49 @@ describe Commander::Methods do
     expect(subject.ancestors).to include(Commander::UI)
   end
 
-  it 'includes Commander::UI::AskForClass' do
-    expect(subject.ancestors).to include(Commander::UI::AskForClass)
+  describe 'AskForClass' do
+    it 'includes Commander::UI::AskForClass' do
+      expect(subject.ancestors).to include(Commander::UI::AskForClass)
+    end
+
+    describe 'defining methods' do
+      let(:terminal) { double }
+
+      before do
+        allow(terminal).to receive(:ask)
+        $_old_terminal = $terminal
+        $terminal = terminal
+      end
+
+      after do
+        $terminal = $_old_terminal
+      end
+
+      subject do
+        Class.new do
+          include Commander::UI::AskForClass
+        end.new
+      end
+
+      it 'defines common "ask_for_*" methods' do
+        expect(subject.respond_to?(:ask_for_float)).to be_truthy
+      end
+
+      it 'responds to "ask_for_*" methods for classes that implement #parse' do
+        expect(subject.respond_to?(:ask_for_datetime)).to be_truthy
+      end
+
+      it 'fails "ask_for_*" method invocations without a prompt' do
+        expect do
+          subject.ask_for_datetime
+        end.to raise_error(ArgumentError)
+      end
+
+      it 'implements "ask_for_*"' do
+        expect(terminal).to receive(:ask)
+        subject.ask_for_datetime('hi')
+      end
+    end
   end
 
   it 'includes Commander::Delegates' do


### PR DESCRIPTION
Related to #62 — here is a way we can avoid triggering deprecation warnings for most users as new constants become deprecated in future versions of Ruby. This patch defers scanning all constants until an `ask_for_*` method is actually called.

@mattbrictson @rous-gg @rlgomes please review if you're interested :)