### PR TITLE
band-aid solution to #70

### DIFF
--- a/lib/commander/command.rb
+++ b/lib/commander/command.rb
@@ -38,6 +38,7 @@ module Commander
     def initialize(name)
       @name, @examples, @when_called = name.to_s, [], []
       @options, @proxy_options = [], []
+      @proxy_option_struct = nil # this is handled separately
     end
 
     ##
@@ -173,6 +174,9 @@ module Commander
     def call(args = [])
       object, meth = @when_called[0, 2]
       meth ||= :call
+
+      # nuke any memoized instance of this thing before running it again
+      @proxy_option_struct = nil
       options = proxy_option_struct
 
       # empty the proxy option stack before the next invocation
@@ -180,7 +184,8 @@ module Commander
 
       case object
       when Proc then object.call(args, options)
-      when Class then meth != :call ? object.new.send(meth, args, options) : object.new(args, options)
+      when Class then meth != :call ? object.new.send(meth, args, options) :
+          object.new(args, options)
       else object.send(meth, args, options) if object
       end
     end
@@ -190,7 +195,8 @@ module Commander
     # collected by the #option_proc.
 
     def proxy_option_struct
-      proxy_options.each_with_object(Options.new) do |(option, value), options|
+      return @proxy_option_struct unless @proxy_option_struct.nil?
+      @proxy_option_struct = proxy_options.each_with_object(Options.new) do |(option, value), options|
         # options that are present will evaluate to true
         value = true if value.nil?
         options.__send__ :"#{option}=", value

--- a/spec/command_spec.rb
+++ b/spec/command_spec.rb
@@ -84,6 +84,13 @@ describe Commander::Command do
         expect(@command.run('--verbose')).to eql('test ')
         expect(@command.proxy_options.empty?).to be true
       end
+
+      it 'should memoize proxy_option_struct' do
+        expect(@command.run('--verbose')).to eql('test ')
+        expect(@command.proxy_option_struct.verbose).to be true
+        expect(@command.run('lol wut')).to eql('test lol wut')
+        expect(@command.proxy_option_struct.verbose).to be nil
+      end
     end
 
     describe 'should populate options with' do


### PR DESCRIPTION
Memoizes `proxy_option_struct` which gets nuked and regenerated once per call.

This won't hurt anything down the line but see issue #70 for my recommendation for a more robust solution.