### PR TITLE
Empty proxy_options before parse

### DIFF
--- a/lib/commander/command.rb
+++ b/lib/commander/command.rb
@@ -161,6 +161,9 @@ module Commander
 
     def parse_options_and_call_procs(*args)
       return args if args.empty?
+      # empty proxy_options before populating via OptionParser
+      # prevents duplication of options if the command is run twice
+      proxy_options.clear
       @options.each_with_object(OptionParser.new) do |option, opts|
         opts.on(*option[:args], &option[:proc])
         opts
@@ -174,9 +177,6 @@ module Commander
       object, meth = @when_called[0, 2]
       meth ||= :call
       options = proxy_option_struct
-
-      # empty the proxy option stack before the next invocation
-      proxy_options.clear
 
       case object
       when Proc then object.call(args, options)

--- a/spec/command_spec.rb
+++ b/spec/command_spec.rb
@@ -80,9 +80,11 @@ describe Commander::Command do
         expect(@command.run('twice')).to eql('test twice')
       end
 
-      it 'should empty @proxy_options after running' do
+      it 'should not accumulate entries in @proxy_options when run twice' do
         expect(@command.run('--verbose')).to eql('test ')
-        expect(@command.proxy_options.empty?).to be true
+        expect(@command.proxy_options).to eq([[:verbose, true]])
+        expect(@command.run('foo')).to eql('test foo')
+        expect(@command.proxy_options).to eq([])
       end
     end
 


### PR DESCRIPTION
This revises d4fd7a53fa2c4bba7a72e0ecdbe4d56a59039de9 to maintain the
proxy_options / proxy_options_struct data after running a command, while
still avoiding the issue of entries accumulating in proxy_options over
multiple runs.