### PR TITLE
Update highline dependency

### DIFF
--- a/commander.gemspec
+++ b/commander.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths = ['lib']
 
-  s.add_runtime_dependency('highline', '~> 1.7.2')
+  s.add_runtime_dependency('highline', '~> 2.0.0')
 
   s.add_development_dependency('rspec', '~> 3.2')
   s.add_development_dependency('rake')

--- a/lib/commander/core_ext/array.rb
+++ b/lib/commander/core_ext/array.rb
@@ -1,7 +1,7 @@
 class Array
   ##
   # Split _string_ into an array. Used in
-  # conjunction with Highline's #ask, or #ask_for_array
+  # conjunction with HighLine's #ask, or #ask_for_array
   # methods, which must respond to #parse.
   #
   # This method allows escaping of whitespace. For example

--- a/lib/commander/help_formatters/terminal/command_help.erb
+++ b/lib/commander/help_formatters/terminal/command_help.erb
@@ -1,22 +1,22 @@
 
-  <%= $terminal.color "NAME", :bold %>:
+  <%= HighLine.default_instance.color "NAME", :bold %>:
 
     <%= @name %>
 <% if @syntax -%>
 
-  <%= $terminal.color "SYNOPSIS", :bold %>:
+  <%= HighLine.default_instance.color "SYNOPSIS", :bold %>:
 
     <%= @syntax -%>
 
 <% end -%>
 
-  <%= $terminal.color "DESCRIPTION", :bold %>:
+  <%= HighLine.default_instance.color "DESCRIPTION", :bold %>:
 
     <%= Commander::HelpFormatter.indent 4, (@description || @summary || 'No description.') -%>
 
 <% unless @examples.empty? -%>
 
-  <%= $terminal.color "EXAMPLES", :bold %>:
+  <%= HighLine.default_instance.color "EXAMPLES", :bold %>:
 	<% for description, command in @examples -%>
 
     # <%= description %>
@@ -25,10 +25,10 @@
 <% end -%>
 <% unless @options.empty? -%>
 
-  <%= $terminal.color "OPTIONS", :bold %>:
+  <%= HighLine.default_instance.color "OPTIONS", :bold %>:
 	<% for option in @options -%>
 
-    <%= option[:switches].join ', ' %> 
+    <%= option[:switches].join ', ' %>
         <%= Commander::HelpFormatter.indent 8, option[:description] %>
 	<% end -%>
 <% end -%>

--- a/lib/commander/help_formatters/terminal/help.erb
+++ b/lib/commander/help_formatters/terminal/help.erb
@@ -1,34 +1,34 @@
-  <%= $terminal.color "NAME", :bold %>:
+  <%= HighLine.default_instance.color "NAME", :bold %>:
 
     <%= program :name %>
 
-  <%= $terminal.color "DESCRIPTION", :bold %>:
+  <%= HighLine.default_instance.color "DESCRIPTION", :bold %>:
 
     <%= Commander::HelpFormatter.indent 4, program(:description) %>
 
-  <%= $terminal.color "COMMANDS", :bold %>:
+  <%= HighLine.default_instance.color "COMMANDS", :bold %>:
 <% for name, command in @commands.sort -%>
 	<% unless alias? name %>
     <%= "%-#{max_command_length}s %s" % [command.name, command.summary || command.description] -%>
 	<% end -%>
 <% end %>
 <% unless @aliases.empty? %>
-  <%= $terminal.color "ALIASES", :bold %>:
+  <%= HighLine.default_instance.color "ALIASES", :bold %>:
   <% for alias_name, args in @aliases.sort %>
     <%= "%-#{max_aliases_length}s %s %s" % [alias_name, command(alias_name).name, args.join(' ')] -%>
   <% end %>
 <% end %>
 <% unless @options.empty? -%>
-  <%= $terminal.color "GLOBAL OPTIONS", :bold %>:
+  <%= HighLine.default_instance.color "GLOBAL OPTIONS", :bold %>:
 	<% for option in @options -%>
 
-    <%= option[:switches].join ', ' %> 
+    <%= option[:switches].join ', ' %>
         <%= option[:description] %>
 	<% end -%>
 <% end -%>
 <% if program :help -%>
   <% for title, body in program(:help) %>
-  <%= $terminal.color title.to_s.upcase, :bold %>:
+  <%= HighLine.default_instance.color title.to_s.upcase, :bold %>:
 
     <%= body %>
   <% end -%>

--- a/lib/commander/methods.rb
+++ b/lib/commander/methods.rb
@@ -4,8 +4,8 @@ module Commander
     include Commander::UI::AskForClass
     include Commander::Delegates
 
-    if $stdin.tty? && (cols = $terminal.output_cols) >= 40
-      $terminal.wrap_at = cols - 5
+    if $stdin.tty? && (cols = HighLine.default_instance.output_cols) >= 40
+      HighLine.default_instance.wrap_at = cols - 5
     end
   end
 end

--- a/lib/commander/runner.rb
+++ b/lib/commander/runner.rb
@@ -448,7 +448,7 @@ module Commander
     end
 
     def say(*args) #:nodoc:
-      $terminal.say(*args)
+      HighLine.default_instance.say(*args)
     end
   end
 end

--- a/lib/commander/user_interaction.rb
+++ b/lib/commander/user_interaction.rb
@@ -66,7 +66,7 @@ module Commander
 
     def say_ok(*args)
       args.each do |arg|
-        say $terminal.color(arg, :green)
+        say HighLine.default_instance.color(arg, :green)
       end
     end
 
@@ -80,7 +80,7 @@ module Commander
 
     def say_warning(*args)
       args.each do |arg|
-        say $terminal.color(arg, :yellow)
+        say HighLine.default_instance.color(arg, :yellow)
       end
     end
 
@@ -94,7 +94,7 @@ module Commander
 
     def say_error(*args)
       args.each do |arg|
-        say $terminal.color(arg, :red)
+        say HighLine.default_instance.color(arg, :red)
       end
     end
 
@@ -113,7 +113,7 @@ module Commander
     #   * highligh: on_<color>
 
     def color(*args)
-      say $terminal.color(*args)
+      say HighLine.default_instance.color(*args)
     end
 
     ##
@@ -329,7 +329,7 @@ module Commander
       # define methods for common classes
       [Float, Integer, String, Symbol, Regexp, Array, File, Pathname].each do |klass|
         define_method "ask_for_#{klass.to_s.downcase}" do |prompt|
-          $terminal.ask(prompt, klass)
+          HighLine.default_instance.ask(prompt, klass)
         end
       end
 
@@ -351,7 +351,7 @@ module Commander
 
           klass = available_classes.find { |k| k.to_s.downcase == requested_class }
           if klass
-            $terminal.ask(prompt, klass)
+            HighLine.default_instance.ask(prompt, klass)
           else
             super
           end
@@ -509,9 +509,9 @@ module Commander
         return if finished?
         erase_line
         if completed?
-          $terminal.say UI.replace_tokens(@complete_message, generate_tokens) if @complete_message.is_a? String
+          HighLine.default_instance.say UI.replace_tokens(@complete_message, generate_tokens) if @complete_message.is_a? String
         else
-          $terminal.say UI.replace_tokens(@format, generate_tokens) << ' '
+          HighLine.default_instance.say UI.replace_tokens(@format, generate_tokens) << ' '
         end
       end
 
@@ -544,7 +544,7 @@ module Commander
 
       def erase_line
         # highline does not expose the output stream
-        $terminal.instance_variable_get('@output').print "\r\e[K"
+        HighLine.default_instance.instance_variable_get('@output').print "\r\e[K"
       end
     end
   end

--- a/spec/methods_spec.rb
+++ b/spec/methods_spec.rb
@@ -16,12 +16,12 @@ describe Commander::Methods do
 
       before do
         allow(terminal).to receive(:ask)
-        $_old_terminal = $terminal
-        $terminal = terminal
+        @old_highline = HighLine.default_instance
+        HighLine.default_instance = terminal
       end
 
       after do
-        $terminal = $_old_terminal
+        HighLine.default_instance = @old_highline
       end
 
       subject do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,7 +18,7 @@ require 'commander/methods'
 def mock_terminal
   @input = StringIO.new
   @output = StringIO.new
-  $terminal = HighLine.new @input, @output
+  HighLine.default_instance = HighLine.new(@input, @output)
 end
 
 # Create test command for usage within several specs


### PR DESCRIPTION
The currently used version of `HighLine` is 1.7.2, which was released mid-2015. This PR updates `HighLine` to the latest version (`2.0.0`).

This version of `HighLine` currently passes tests on all ruby versions listed in [.travis.yml](https://github.com/commander-rb/commander/blob/master/.travis.yml#L6). However, ruby `1.9.3` doesn't seem to be 'officially' supported, `HighLine`'s `.travis.yml` [allows failures on `1.9.3`](https://github.com/JEG2/highline/blob/bf489b632afd92c68df0b2c1f348afb66b5495aa/.travis.yml#L19-L24). 