### PR TITLE
Allow --trace option without the error message prompt

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -15,7 +15,7 @@ Lint/HandleExceptions:
 
 # Offense count: 5
 Metrics/AbcSize:
-  Max: 29
+  Max: 30
 
 # Offense count: 1
 # Configuration parameters: CountComments.

--- a/README.md
+++ b/README.md
@@ -435,6 +435,12 @@ Or make it always on:
 always_trace!
 ```
 
+Include the `--trace` global option but turn off the error message prompt:
+
+```ruby
+silent_trace!
+```
+
 ## Tips
 
 When adding a global or command option, OptionParser implicitly adds a small

--- a/lib/commander/delegates.rb
+++ b/lib/commander/delegates.rb
@@ -10,6 +10,7 @@ module Commander
       default_command
       always_trace!
       never_trace!
+      silent_trace!
     ).each do |meth|
       eval <<-END, binding, __FILE__, __LINE__
         def #{meth}(*args, &block)

--- a/lib/commander/runner.rb
+++ b/lib/commander/runner.rb
@@ -34,6 +34,7 @@ module Commander
       @program = program_defaults
       @always_trace = false
       @never_trace = false
+      @silent_trace = false
       create_default_commands
     end
 
@@ -77,7 +78,7 @@ module Commander
           OptionParser::MissingArgument => e
           abort e.to_s
         rescue => e
-          if @never_trace
+          if @never_trace || @silent_trace
             abort "error: #{e}."
           else
             abort "error: #{e}. Use --trace to view backtrace"
@@ -99,14 +100,25 @@ module Commander
     def always_trace!
       @always_trace = true
       @never_trace = false
+      @silent_trace = false
     end
 
     ##
     # Hide the trace option from the help menus and don't add it as a global option
 
     def never_trace!
-      @never_trace = true
       @always_trace = false
+      @never_trace = true
+      @silent_trace = false
+    end
+
+    ##
+    # Includes the trace option in the help but not in the error message
+
+    def silent_trace!
+      @always_trace = false
+      @never_trace = false
+      @silent_trace = true
     end
 
     ##

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -381,6 +381,30 @@ describe Commander do
     end
   end
 
+  describe '#silent_trace!' do
+    it 'should allow the --trace option' do
+      expect do
+        new_command_runner 'help', '--trace' do
+          silent_trace!
+        end.run!
+      end.not_to raise_error
+    end
+
+    it 'should not prompt to use --trace switch on errors' do
+      msg = nil
+      begin
+        new_command_runner 'foo' do
+          silent_trace!
+          command(:foo) { |c| c.when_called { fail 'cookies!' } }
+        end.run!
+      rescue SystemExit => e
+        msg = e.message
+      end
+      expect(msg).to match(/error: cookies!/)
+      expect(msg).not_to match(/--trace/)
+    end
+  end
+
   context 'conflict between #always_trace! and #never_trace!' do
     it 'respects the last used command' do
       expect do


### PR DESCRIPTION
Description:

Allow `--trace` to toggle the traceback without modifying the error messages. The option still appears in the global help text, as expected.

Motivation:

A lot of my application rely on valid input data (e.g. a file path). This results in user errors which get appended with: ` Use --trace to view backtrace`

By disabling the message, the user can focus on the rest of the message.