### PR TITLE
Add project metadata to the gemspec

### DIFF
--- a/commander.gemspec
+++ b/commander.gemspec
@@ -12,6 +12,13 @@ Gem::Specification.new do |s|
   s.homepage    = 'https://github.com/commander-rb/commander'
   s.summary     = 'The complete solution for Ruby command-line executables'
   s.description = 'The complete solution for Ruby command-line executables. Commander bridges the gap between other terminal related libraries you know and love (OptionParser, HighLine), while providing many new features, and an elegant API.'
+  s.metadata    = {
+    'bug_tracker_uri'   => "#{s.homepage}/issues",
+    'changelog_uri'     => "#{s.homepage}/blob/master/History.rdoc",
+    'documentation_uri' => "https://www.rubydoc.info/gems/commander/#{s.version}",
+    'homepage_uri'      => s.homepage,
+    'source_code_uri'   => "#{s.homepage}/tree/v#{s.version}",
+  }
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")


### PR DESCRIPTION
Add `bug_tracker_uri`, `changelog_uri`, `documentation_uri`, `homepage_uri`, and `source_code_uri` to the gemspec metadata.

These [project metadata](https://guides.rubygems.org/specification-reference/#metadata) will facilitate easy access to project information. The URI will be available on the [Rubygems project page](https://rubygems.org/gems/commander), via the rubygems API, and the `gem` and `bundle` command-line tools with the next release.