### PR TITLE
Fix: Global option values ignored when args provided

### DIFF
--- a/lib/commander/command.rb
+++ b/lib/commander/command.rb
@@ -4,6 +4,7 @@ module Commander
   class Command
     attr_accessor :name, :examples, :syntax, :description
     attr_accessor :summary, :proxy_options, :options
+    attr_reader :global_options
 
     ##
     # Options struct.
@@ -38,6 +39,7 @@ module Commander
     def initialize(name)
       @name, @examples, @when_called = name.to_s, [], []
       @options, @proxy_options = [], []
+      @global_options = []
     end
 
     ##
@@ -190,7 +192,7 @@ module Commander
     # collected by the #option_proc.
 
     def proxy_option_struct
-      proxy_options.each_with_object(Options.new) do |(option, value), options|
+      (global_options + proxy_options).each_with_object(Options.new) do |(option, value), options|
         # options that are present will evaluate to true
         value = true if value.nil?
         options.__send__ :"#{option}=", value

--- a/lib/commander/runner.rb
+++ b/lib/commander/runner.rb
@@ -395,7 +395,7 @@ module Commander
     def global_option_proc(switches, &block)
       lambda do |value|
         unless active_command.nil?
-          active_command.proxy_options << [Runner.switch_to_sym(switches.last), value]
+          active_command.global_options << [Runner.switch_to_sym(switches.last), value]
         end
         yield value if block && !value.nil?
       end

--- a/spec/command_spec.rb
+++ b/spec/command_spec.rb
@@ -164,6 +164,33 @@ describe Commander::Command do
         end
         @command.run '--interval', '15'
       end
+
+      describe 'given a global option' do
+        before do
+          @command.global_options << [:global_option, 'gvalue']
+        end
+
+        describe 'and no command specific arguments' do
+          it 'provides the global option to the command action' do
+            @command.when_called { |_, options| expect(options.global_option).to eq('gvalue') }
+            @command.run
+          end
+        end
+
+        describe 'and a command specific option' do
+          it 'provides the global option to the command action' do
+            @command.when_called { |_, options| expect(options.global_option).to eq('gvalue') }
+            @command.run '--verbose'
+          end
+        end
+
+        describe 'and a command specific argument' do
+          it 'provides the global option to the command action' do
+            @command.when_called { |_, options| expect(options.global_option).to eq('gvalue') }
+            @command.run 'argument'
+          end
+        end
+      end
     end
   end
 end

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -132,6 +132,40 @@ describe Commander do
       end.run!
       expect(quiet).to be false
     end
+
+    it 'should allow command arguments before the global option' do
+      config = nil
+      args = nil
+      new_command_runner 'foo', '--config', 'config-value', 'arg1', 'arg2' do
+        global_option('-c', '--config CONFIG', String)
+        command :foo do |c|
+          c.when_called do |arguments, options|
+            options.default(config: 'default')
+            args = arguments
+            config = options.config
+          end
+        end
+      end.run!
+      expect(config).to eq('config-value')
+      expect(args).to eq(%w(arg1 arg2))
+    end
+
+    it 'should allow command arguments after the global option' do
+      config = nil
+      args = nil
+      new_command_runner 'foo', 'arg1', 'arg2', '--config', 'config-value' do
+        global_option('-c', '--config CONFIG', String)
+        command :foo do |c|
+          c.when_called do |arguments, options|
+            options.default(config: 'default')
+            args = arguments
+            config = options.config
+          end
+        end
+      end.run!
+      expect(config).to eq('config-value')
+      expect(args).to eq(%w(arg1 arg2))
+    end
   end
 
   describe '#parse_global_options' do


### PR DESCRIPTION
### Context

As detailed in #86, global options are ignored when command specific options or arguments are provided.

### Proposed Solution

Separate the global options from the command specific options. This prevents the global options from being cleared when the command specific options are parsed.

Fixes #86.

