### PR TITLE
Fix command name identification

### DIFF
--- a/lib/commander/runner.rb
+++ b/lib/commander/runner.rb
@@ -246,6 +246,7 @@ module Commander
     # Returns array of valid command names found within _args_.
 
     def valid_command_names_from(*args)
+      remove_global_options options, args
       arg_string = args.delete_if { |value| value =~ /^-/ }.join ' '
       commands.keys.find_all { |name| name if arg_string =~ /^#{name}\b/ }
     end

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -100,6 +100,17 @@ describe Commander do
       expect(quiet).to be true
     end
 
+    it 'should be inherited by commands when provided before the command name' do
+      option = nil
+      new_command_runner '--global-option', 'option-value', 'command_name' do
+        global_option('--global-option=GLOBAL', 'A global option')
+        command :command_name do |c|
+          c.when_called { |_, options| option = options.global_option }
+        end
+      end.run!
+      expect(option).to eq('option-value')
+    end
+
     it 'should be inherited by commands even when a block is present' do
       quiet = nil
       new_command_runner 'foo', '--quiet' do
@@ -492,6 +503,13 @@ describe Commander do
   describe '#command_name_from_args' do
     it 'should locate command within arbitrary arguments passed' do
       new_command_runner '--help', '--arbitrary', 'test'
+      expect(command_runner.command_name_from_args).to eq('test')
+    end
+
+    it 'should locate command when provided after a global argument with value' do
+      new_command_runner '--global-option', 'option-value', 'test' do
+        global_option('--global-option=GLOBAL', 'A global option')
+      end
       expect(command_runner.command_name_from_args).to eq('test')
     end
 


### PR DESCRIPTION
### Context 

In issue #32, it is reported that global options are not available at command level when placed before command name. I found this to be a defect in the identification of command names from arguments.

https://github.com/commander-rb/commander/blob/0abbac486ea7d87f6f680aaf17d0e3cd136dbf73/lib/commander/runner.rb#L248-L251

This method was not correctly accounting for global options with provided values. ie. in the example provided by @msabramo:

```sh
aptly-cli --server 10.3.0.46 repo_list
```

It would incorrectly determine the `args_string` to be `"10.3.0.46 repo_list"` thus expecting the command name to start with `10.3.0.46`.

### Proposed Fix

I propose the `valid_command_names_from` method be modified to remove all global options from the args. This way it correctly identify the command name(s).

This will result in the  `global_option_proc` finding a non-nil `active_command` and thus provide it the global option.

https://github.com/commander-rb/commander/blob/0abbac486ea7d87f6f680aaf17d0e3cd136dbf73/lib/commander/runner.rb#L395-L402

Fixes #32.