### PR TITLE
Small optimisation of remove_global_options

### DIFF
--- a/lib/commander/runner.rb
+++ b/lib/commander/runner.rb
@@ -329,13 +329,9 @@ module Commander
 
     def remove_global_options(options, args)
       options.each do |option|
-        switches = option[:switches].dup
+        switches = option[:switches]
         next if switches.empty?
-
-        if (switch_has_arg = switches.any? { |s| s =~ /[ =]/ })
-          switches.map! { |s| s[0, s.index('=') || s.index(' ') || s.length] }
-        end
-
+        switch_has_arg = switches.any? { |s| s =~ /[ =]/ }
         switches = expand_optionally_negative_switches(switches)
 
         past_switch, arg_removed = false, false


### PR DESCRIPTION
I notice there's no need to mutate the `switches` array.

https://github.com/commander-rb/commander/blob/0abbac486ea7d87f6f680aaf17d0e3cd136dbf73/lib/commander/runner.rb#L336

As only first portion of each switch is compared to the argument.

https://github.com/commander-rb/commander/blob/0abbac486ea7d87f6f680aaf17d0e3cd136dbf73/lib/commander/runner.rb#L344

I propose to remove this mutation.


