### PR TITLE
Fix ERB for Ruby v2.7 warnings (no. 2)

### DIFF
--- a/lib/commander/help_formatters/terminal.rb
+++ b/lib/commander/help_formatters/terminal.rb
@@ -12,7 +12,11 @@ module Commander
       end
 
       def template(name)
-        ERB.new(File.read(File.join(File.dirname(__FILE__), 'terminal', "#{name}.erb")), nil, '-')
+        if RUBY_VERSION < '2.6'
+          ERB.new(File.read(File.join(File.dirname(__FILE__), 'terminal', "#{name}.erb")), nil, '-')
+        else
+          ERB.new(File.read(File.join(File.dirname(__FILE__), 'terminal', "#{name}.erb")), trim_mode: '-')
+        end
       end
     end
   end

--- a/lib/commander/help_formatters/terminal_compact.rb
+++ b/lib/commander/help_formatters/terminal_compact.rb
@@ -4,7 +4,11 @@ module Commander
   module HelpFormatter
     class TerminalCompact < Terminal
       def template(name)
-        ERB.new(File.read(File.join(File.dirname(__FILE__), 'terminal_compact', "#{name}.erb")), nil, '-')
+        if RUBY_VERSION < '2.6'
+          ERB.new(File.read(File.join(File.dirname(__FILE__), 'terminal_compact', "#{name}.erb")), nil, '-')
+        else
+          ERB.new(File.read(File.join(File.dirname(__FILE__), 'terminal_compact', "#{name}.erb")), trim_mode: '-')
+        end
       end
     end
   end


### PR DESCRIPTION
Try no. 2 to fix Ruby v2.7 warnings.

```
~/.gem/ruby/2.7.0/gems/commander-4.5.1/lib/commander/help_formatters/terminal.rb:15: warning: Passing safe_level with the 2nd argument of ERB.new is deprecated. Do not use it, and specify other arguments as keyword arguments.
~/.gem/ruby/2.7.0/gems/commander-4.5.1/lib/commander/help_formatters/terminal.rb:15: warning: Passing trim_mode with the 3rd argument of ERB.new is deprecated. Use keyword argument like ERB.new(str, trim_mode: ...) instead.
```