### PR TITLE
Use --help after command and argument

### DIFF
--- a/lib/commander/runner.rb
+++ b/lib/commander/runner.rb
@@ -237,9 +237,18 @@ module Commander
     ##
     # Attempts to locate a command name from within the arguments.
     # Supports multi-word commands, using the largest possible match.
+    # Returns the default command, if no valid commands found in the args.
 
     def command_name_from_args
-      @__command_name_from_args ||= (valid_command_names_from(*@args.dup).sort.last || @default_command)
+      @__command_name_from_args ||= (longest_valid_command_name_from(@args) || @default_command)
+    end
+
+    ##
+    # Attempts to locate a command name from within the provided arguments.
+    # Supports multi-word commands, using the largest possible match.
+
+    private def longest_valid_command_name_from(args)
+      valid_command_names_from(*args.dup).max
     end
 
     ##
@@ -304,7 +313,7 @@ module Commander
           if args.empty?
             say help_formatter.render
           else
-            command = command args.join(' ')
+            command = command(longest_valid_command_name_from(args))
             begin
               require_valid_command command
             rescue InvalidCommandError => e

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -484,6 +484,22 @@ describe Commander do
       expect(run('test', '--help')).to eq("Implement help for test here\n")
     end
 
+    it 'can be used after the command and command arguments' do
+      expect(run('test', 'command-arg', '--help')).to eq("Implement help for test here\n")
+    end
+
+    it 'can be used before a single-word command with command arguments' do
+      expect(run('help', 'test', 'command-arg')).to eq("Implement help for test here\n")
+    end
+
+    it 'can be used before a multi-word command with command arguments' do
+      expect(
+        run('help', 'module', 'install', 'command-arg') do
+          command('module install') { |c| c.when_called { say 'whee!' } }
+        end
+      ).to eq("Implement help for module install here\n")
+    end
+
     describe 'help_paging program information' do
       it 'enables paging when enabled' do
         run('--help') { program :help_paging, true }


### PR DESCRIPTION
#### Context

It is reported in #94 that using `--help` after a command name and command argument does not work.

```
$ mycli command-name command-arg --help
invalid command. Use --help for more information
```

Investigation finds the `help` command is assuming the the command name is all the arguments joined together.

https://github.com/commander-rb/commander/blob/b8abd42153118ca9fdc02affeb9f3aab61cda5a2/lib/commander/runner.rb#L307

#### Change

Fix #94 by changing the line in question to ignore the command argument when searching for command name. Just take the longest valid command name found in the arguments.

#### Considerations

This also changes the behaviour of the help command in its alternate form. This will ignore the argument and provide the documentation for the specified command, where previously it would give an error message.

```
mycli help command-name command-arg
```

