### PR TITLE
Exclude test files

### DIFF
--- a/commander.gemspec
+++ b/commander.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   }
   s.required_ruby_version = '>= 2.4'
 
-  s.files         = `git ls-files`.split("\n")
+  s.files         = `git ls-files`.split("\n").reject { |f| f.match(%r{^(test|spec|features)/}) }
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths = ['lib']


### PR DESCRIPTION
Test files are already marked in the line before. We should exclude them from the necessary gem files.