### PR TITLE
Update highline

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 inherit_from: .rubocop_todo.yml
 
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 3.0
   NewCops: enable
   SuggestExtensions: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,9 @@ before_install:
   - gem update --system
   - gem update bundler
 rvm:
-  - 2.4
-  - 2.5
-  - 2.6
-  - 2.7
   - 3.0
+  - 3.1
+  - 3.2
+  - 3.3
   - jruby
   - ruby-head

--- a/commander.gemspec
+++ b/commander.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths = ['lib']
 
-  s.add_runtime_dependency('highline', '~> 2.0.0')
+  s.add_runtime_dependency('highline', '~> 3.0.0')
 
   s.add_development_dependency('rake')
   s.add_development_dependency('rspec', '~> 3.2')

--- a/commander.gemspec
+++ b/commander.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
     'homepage_uri' => s.homepage,
     'source_code_uri' => "#{s.homepage}/tree/v#{s.version}",
   }
-  s.required_ruby_version = '>= 2.4'
+  s.required_ruby_version = '>= 3.0'
 
   s.files         = `git ls-files`.split("\n").reject { |f| f.match(%r{^(test|spec|features)/}) }
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")

--- a/lib/commander/delegates.rb
+++ b/lib/commander/delegates.rb
@@ -20,8 +20,8 @@ module Commander
       END
     end
 
-    def defined_commands(*args, &block)
-      ::Commander::Runner.instance.commands(*args, &block)
+    def defined_commands(...)
+      ::Commander::Runner.instance.commands(...)
     end
   end
 end

--- a/lib/commander/user_interaction.rb
+++ b/lib/commander/user_interaction.rb
@@ -344,12 +344,10 @@ module Commander
           # All Classes that respond to #parse
           # Ignore constants that trigger deprecation warnings
           available_classes = (Object.constants - DEPRECATED_CONSTANTS).map do |const|
-            begin
-              Object.const_get(const)
-            rescue RuntimeError
-              # Rescue errors in Ruby 3 for SortedSet:
-              # The `SortedSet` class has been extracted from the `set` library.
-            end
+            Object.const_get(const)
+          rescue RuntimeError
+            # Rescue errors in Ruby 3 for SortedSet:
+            # The `SortedSet` class has been extracted from the `set` library.
           end.compact.select do |const|
             const.instance_of?(Class) && const.respond_to?(:parse)
           end


### PR DESCRIPTION
Update highline gem to fix ruby 3.3 [warning](https://github.com/JEG2/highline/blob/master/Changelog.md#300--2024-01-05)

Increase ruby version to match highline gem requirements

